### PR TITLE
Password compare fix

### DIFF
--- a/src/main/java/com/Energy/BasicSpringAPI/service/AuthService.java
+++ b/src/main/java/com/Energy/BasicSpringAPI/service/AuthService.java
@@ -19,21 +19,12 @@ public class AuthService {
     }
 
     public Optional<UserEntity> getUser(String email, String password) {
-
-        try {
-            if (userRepository.existsByEmail(email)) {
-                String hashedPassword = AuthenticationFilter.getBcryptHash(password);
-                Optional<UserEntity> user =  userRepository.findByEmail(email);
-
-                if (user.isPresent() && user.get().password.equals(hashedPassword)){
-                    return user;
-                }
-                return Optional.empty();
+        if (userRepository.existsByEmail(email)) {
+            Optional<UserEntity> user = userRepository.findByEmail(email);
+            if (user.isPresent() && AuthenticationFilter.isPasswordValid(password, user.get().getPassword())) {
+                return user;
             }
             return Optional.empty();
-
-        } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
         }
         return Optional.empty();
     }

--- a/src/main/java/com/Energy/BasicSpringAPI/service/AuthenticationFilter.java
+++ b/src/main/java/com/Energy/BasicSpringAPI/service/AuthenticationFilter.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.*;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+
 import javax.crypto.spec.SecretKeySpec;
 import javax.xml.bind.DatatypeConverter;
 import java.nio.charset.StandardCharsets;
@@ -17,10 +18,10 @@ import java.time.ZonedDateTime;
 public class AuthenticationFilter {
 
     @Deprecated
-    public static String doHashing (String password) throws NoSuchAlgorithmException {
+    public static String doHashing(String password) throws NoSuchAlgorithmException {
         final MessageDigest digest = MessageDigest.getInstance("SHA3-256");
         final byte[] hashBytes = digest.digest(
-                password.getBytes(StandardCharsets.UTF_8));
+            password.getBytes(StandardCharsets.UTF_8));
         String sha3Hex = bytesToHex(hashBytes);
 
         return sha3Hex;
@@ -31,7 +32,7 @@ public class AuthenticationFilter {
         StringBuilder hexString = new StringBuilder(2 * hash.length);
         for (int i = 0; i < hash.length; i++) {
             String hex = Integer.toHexString(0xff & hash[i]);
-            if(hex.length() == 1) {
+            if (hex.length() == 1) {
                 hexString.append('0');
             }
             hexString.append(hex);
@@ -45,7 +46,12 @@ public class AuthenticationFilter {
     }
 
     private static PasswordEncoder getPasswordEncoder() {
-        return new BCryptPasswordEncoder(16);
+        return new BCryptPasswordEncoder();
+    }
+
+    public static Boolean isPasswordValid(String currentPassword, String dbPassword) {
+        Boolean isMatched = getPasswordEncoder().matches(currentPassword, dbPassword);
+        return isMatched;
     }
 
     //    public UserEntity getUserFromToken(String token) {
@@ -75,11 +81,11 @@ public class AuthenticationFilter {
 
         //Let's set the JWT Claims
         JwtBuilder builder = Jwts.builder().setId(id)
-                .setIssuedAt(now)
-                .setSubject(subject)
-                .setIssuer(issuer)
-                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(1).toInstant()))
-                .signWith(signatureAlgorithm, signingKey);
+            .setIssuedAt(now)
+            .setSubject(subject)
+            .setIssuer(issuer)
+            .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(1).toInstant()))
+            .signWith(signatureAlgorithm, signingKey);
 
         //Builds the JWT and serializes it to a compact, URL-safe string
 
@@ -89,12 +95,12 @@ public class AuthenticationFilter {
     public boolean validateToken(String token) {
         boolean validation = false;
         try {
-            Jws<Claims> claims  = Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token);
+            Jws<Claims> claims = Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token);
             validation = !claims.getBody().getExpiration().before(new java.util.Date());
 
         } catch (ExpiredJwtException e) {
             System.out.println(" Token expired ");
-        } catch(Exception e){
+        } catch (Exception e) {
             System.out.println(" Some other exception in JWT parsing ");
         }
         return validation;
@@ -103,7 +109,7 @@ public class AuthenticationFilter {
     public Claims decodeJWT(String jwt) {
         //This line will throw an exception if it is not a signed JWS (as expected)
         return Jwts.parser()
-                .setSigningKey(DatatypeConverter.parseBase64Binary(SECRET_KEY))
-                .parseClaimsJws(jwt).getBody();
+            .setSigningKey(DatatypeConverter.parseBase64Binary(SECRET_KEY))
+            .parseClaimsJws(jwt).getBody();
     }
 }


### PR DESCRIPTION
Fixes a bug where the password comparison would fail because BCrypt always generates a new salt when hashing a password.
This is intended behaviour to make sure that the users which have the same password have a different hash so they don't get compromised simultaneously.

Instead of generating a hash again by using the comparison method, BCrypt retrieves the salt first and hashes with the same salt to make sure the comparison always uses the same salt.